### PR TITLE
Fix show password error on Auth.js to false when registering

### DIFF
--- a/src/views/auth/Auth.js
+++ b/src/views/auth/Auth.js
@@ -185,7 +185,7 @@ export default function Auth() {
                 label="Password"
                 required
                 handleChange={handleChange}
-                type={showPassword ? 'text' : 'password'}
+                type={!showPassword ? 'text' : 'password'}
                 handleShowPassword={handleShowPassword}
               />
               {isSignup && (


### PR DESCRIPTION
on `/login` →  and when `Do not have an account? ...` link is clicked, the register form is `switched`. It is currently showing the password on default.

This PR fixed that error by changing `password input` type:
```
type={showPassword ? 'text' : 'password'}
```
to:
```
type={!showPassword ? 'text' : 'password'}
```