### PR TITLE
Fix route link from '/auth' to '/' on Navbar

### DIFF
--- a/src/components/navigation/DesktopBreakpoint.js
+++ b/src/components/navigation/DesktopBreakpoint.js
@@ -21,7 +21,7 @@ const DesktopBreakpoint = () => {
           alignItems: 'center',
         }}
       >
-        <Button variant="container" href="/auth">
+        <Button variant="container" href="/">
           Home
         </Button>
         <Button href="/about" variant="container">

--- a/src/components/navigation/DynamicButtons.js
+++ b/src/components/navigation/DynamicButtons.js
@@ -27,7 +27,7 @@ const DynamicButtons = () => {
 
   const logout = () => {
     dispatch({ type: 'LOGOUT' });
-    navigate('/auth');
+    navigate('/');
   };
 
   useEffect(() => {
@@ -57,7 +57,7 @@ const DynamicButtons = () => {
             Create a Post
           </Button>
           <Button
-            href="/auth"
+            href="/"
             onClick={(e) => {
               e.preventDefault();
               logout();


### PR DESCRIPTION
minor fix to any `"/auth"` route on the Navbar
there seems to be a bug on Mobile view that on logout, it still redirects it to `/auth` even though it's set to `/` 😢 