### PR TITLE
fix auth

### DIFF
--- a/src/context/UserContext.js
+++ b/src/context/UserContext.js
@@ -1,15 +1,12 @@
 import React, { useState, useContext } from 'react';
-import useFirebase from '../utils/hooks/useFirebase';
 
 const UserContext = React.createContext();
 
 function UserContextProvider(props) {
   const [currentId, setCurrentId] = useState(0);
 
-  const firebase = useFirebase();
-
   return (
-    <UserContext.Provider value={{ currentId, setCurrentId, firebase }}>
+    <UserContext.Provider value={{ currentId, setCurrentId }}>
       {props.children}
     </UserContext.Provider>
   );

--- a/src/views/auth/Auth.js
+++ b/src/views/auth/Auth.js
@@ -98,6 +98,8 @@ export default function Auth() {
     }
   };
 
+  console.log('--FORMDATA: ', formData);
+
   return (
     <div data-testid="form">
       <Header title={isSignup ? 'Register' : 'Login'} />
@@ -130,14 +132,20 @@ export default function Auth() {
                     </Typography>
                     <FormControl component="fieldset">
                       <FormLabel component="legend"></FormLabel>
-                      <RadioGroup row name="row-radio-buttons-group">
+                      <RadioGroup
+                        row
+                        aria-label="proGroomer"
+                        name="proGroomer"
+                        value={formData.proGroomer}
+                        onChange={handleChange}
+                      >
                         <FormControlLabel
-                          value="Yes"
+                          value="true"
                           control={<Radio />}
                           label="Yes"
                         />
                         <FormControlLabel
-                          value="No"
+                          value="false"
                           control={<Radio />}
                           label="No"
                         />
@@ -151,12 +159,12 @@ export default function Auth() {
                     handleChange={handleChange}
                     type="text"
                   />
-                  <Input
+                  {/* <Input
                     name="socMedia"
                     label="Social media"
                     handleChange={handleChange}
                     type="text"
-                  />
+                  /> */}
                 </>
               )}
 

--- a/src/views/auth/Auth.js
+++ b/src/views/auth/Auth.js
@@ -17,6 +17,7 @@ import {
   FormLabel,
   Radio,
   Box,
+  Stack,
 } from '@mui/material';
 import LockIcon from '@mui/icons-material/Lock';
 import useStyles from './styles';
@@ -60,8 +61,8 @@ export default function Auth() {
   // Toggling between Sign up and Sign In
   const switchMode = () => {
     setIsSignup((preIsSignup) => !preIsSignup);
-
-    handleShowPassword(false);
+    // always have the show password to false
+    setShowPassword(false);
   };
 
   // Will update our formData with its respective field.
@@ -106,10 +107,6 @@ export default function Auth() {
             <LockIcon />
           </Avatar>
 
-          {/* <Typography component="h1" variant="h5">
-            {isSignup ? 'Sign up' : 'Sign in'}
-          </Typography> */}
-
           <form onSubmit={handleSubmit}>
             <Grid container spacing={2} sx={{ mb: 3 }}>
               {isSignup && (
@@ -123,12 +120,10 @@ export default function Auth() {
                     required
                   />
 
-                  <Grid
-                    item
-                    direction="row"
+                  <Stack
+                    direction="column"
                     justifyContent="flex-start"
-                    // margin="15px 0 5px 0 "
-                    sx={{ mt: 1, ml: 1 }}
+                    sx={{ pl: 1.5, mt: 2, ml: 1 }}
                   >
                     <Typography variant="subtitle1" sx={{ marginRight: 8 }}>
                       Are you a professional dog groomer?
@@ -146,14 +141,9 @@ export default function Auth() {
                           control={<Radio />}
                           label="No"
                         />
-                        {/* <FormControlLabel
-                            value="other"
-                            control={<Radio />}
-                            label="Other"
-                          /> */}
                       </RadioGroup>
                     </FormControl>
-                  </Grid>
+                  </Stack>
 
                   <Input
                     name="location"
@@ -182,7 +172,7 @@ export default function Auth() {
                 label="Password"
                 required
                 handleChange={handleChange}
-                type={!showPassword ? 'text' : 'password'}
+                type={showPassword ? 'text' : 'password'}
                 handleShowPassword={handleShowPassword}
               />
               {isSignup && (


### PR DESCRIPTION
- the previous supposedly 'fixed' show password default state I said I've fixed was wrong... 😓 Now the `Login` or `Register` page's `password` field will always be in password state →  the found bug was on the `switchMode` that it's using the wrong function
- didn't realise that the `Are you a professional groomer?` section wasn't done properly / incomplete as the backend doesn't accept correct value (always false) →  it didn't have the `onChange` configured. It's now fixed. Whenever a user picks 'yes' the `proGroomer` will be true. 
- also a minor cleanup on unnecessary codes